### PR TITLE
[GRX-123456] Adding missing Dip Switch Settings for Double Dragon 2

### DIFF
--- a/fbarr/src/burn/drivers/misc_pre90s/d_ddragon.cpp
+++ b/fbarr/src/burn/drivers/misc_pre90s/d_ddragon.cpp
@@ -214,6 +214,22 @@ static struct BurnDIPInfo Drv2DIPList[]=
 	{0x14, 0x01, 0x80, 0x00, "On"                     },
 	
 	// Dip 2
+	// Note the difficulty settings were pulled from MAME
+	// Do not use the real Double Dragon 2 Manual as
+	// reference, because it lists wrong settings!
+	//
+	// If anyone points you to bad settings from Manual
+	//  they will look like this:
+	//   OFF OFF = Normal
+	//   OFF OFF = Easy
+	//   ON  OFF = Less Than Difficult
+	//   ON  ON  = Difficult
+	{0   , 0xfe, 0   , 4   , "Difficulty"             },
+	{0x15, 0x01, 0x03, 0x01, "Easy"                   },
+	{0x15, 0x01, 0x03, 0x03, "Medium"                 },
+	{0x15, 0x01, 0x03, 0x02, "Hard"                   },
+	{0x15, 0x01, 0x03, 0x00, "Hardest"                },
+
 	{0   , 0xfe, 0   , 2   , "Hurricane Kick"         },
 	{0x15, 0x01, 0x08, 0x00, "Easy"                   },
 	{0x15, 0x01, 0x08, 0x08, "Normal"                 },


### PR DESCRIPTION
## Overview

The Dip Switch settings were never added in FBbarr. These
values come from MAME source code: https://github.com/mamedev/mame/blob/master/src/mame/drivers/ddragon.cpp#L663

Note: do not reference dip switch settings in original manual,
because they are wrong!

## Why are we fixing this

As part of TAS project for Double Dragon 2, I need access to Dip Switch settings. Without these, TAS Runners are stuck doing runs on Medium [Default] Difficulty, which will not be a valid submission for TAS videos.

## Ticket

http://loren-ipsum/GRX-123456

## NOTES

For reference, here's image of the bad Dip Switch Settings in original Double Dragon 2 Hardware manual

![](https://user-images.githubusercontent.com/1490512/38176349-f0131d6e-35a1-11e8-9455-ffcbb08d65e5.png)

## Tests

All Dip Switch settings have been verified using RAM Watch (verified health point scaling)